### PR TITLE
Update gitignore, based on other Godot gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,21 @@
+
+# Godot-specific ignores
+.import/
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
+
 # VS Code
 /.vscode
 /.vs
-
-# Godot
-/.import
 
 # JetBrains
 /.idea


### PR DESCRIPTION
This updates the gitignore file to be based on [this](https://github.com/godotengine/godot-demo-projects/blob/master/.gitignore), with the other stuff at the end.

It's useful to keep the gitignore in sync with Godot even if not everything in it applies for this project. One practical use case is opening this project in a C# enabled version of Godot will create a `.mono` folder, even if the user doesn't create any C# scripts or use C# in any way, and it should be ignored.