### PR TITLE
Add a plugin config file to make it an actual plugin

### DIFF
--- a/addons/enjin/plugin.cfg
+++ b/addons/enjin/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Enjin Blockchain SDK"
+description="Blockchain SDK by Enjin for Godot https://enjin.io/"
+author="Enjin"
+version="1.0"
+script=""

--- a/project.godot
+++ b/project.godot
@@ -238,6 +238,10 @@ window/vsync/vsync_via_compositor=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 
+[editor_plugins]
+
+enabled=PoolStringArray( "enjin" )
+
 [global]
 
 warnings/return_value_discarded=false


### PR DESCRIPTION
This allows the Enjin plugin to be registered as an actual Godot plugin so it can be easily enabled or disabled from Godot's UI. This also allows users to view metadata such as the plugin version and description from the plugin menu.