### PR TITLE
Fix a link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Documentation
    * [Authentication](https://github.com/enjin/Enjin-Coin-Documentation/blob/master/docs/godot_authentication.md)
    * [Player Management](https://github.com/enjin/Enjin-Coin-Documentation/blob/master/docs/godot_player_management.md)
    * [Creating Requests](https://github.com/enjin/Enjin-Coin-Documentation/blob/master/docs/godot_creating_requests.md)
-   * [Demo Game Documentation](https://github.com/enjin/enjin-godot-sdk/blob/feature-demo-docs/addons/enjin/example/README.md)
+   * [Demo Game Documentation](addons/enjin/example/README.md)


### PR DESCRIPTION
This link pointed to a branch that didn't exist. I changed it to just point to a file, so that it will work correctly on any branch. The other links point to another repo and can't be simplified in this way.