### PR TITLE
Fix for submodules installation via Travis CI.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "addons/enjin/sdk/graphql/templates"]
 	path = addons/enjin/sdk/graphql/templates
-	url = git@github.com:enjin/Enjin-SDK-GraphQL-Templates.git
+	url = https://github.com/enjin/Enjin-SDK-GraphQL-Templates.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 dist: bionic
 
-git:
-  submodules: false
-
-before_install:
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive
-
 stages:
   - build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 dist: bionic
 
+git:
+  submodules: false
+
+before_install:
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
+
 stages:
   - build
 


### PR DESCRIPTION
This is a fix for submodules currently being cloned over SSH with Travis CI.

For compatibility reasons, it's more preferred we change the submodule URLs over to HTTPS as anyone will be able to access the submodules without the need for a public key beforehand. This is especially useful for Travis CI which doesn't have a default public key and therefore fails.